### PR TITLE
Issue #35 fixed tempC/tempF KeyError

### DIFF
--- a/python_weather/forecast.py
+++ b/python_weather/forecast.py
@@ -166,8 +166,10 @@ class HourlyForecast(BaseForecast):
   
   def __init__(self, json: dict, unit: auto, locale: Locale):
     # for inheritance purposes
-    json['temp_C'] = json.pop('tempC')
-    json['temp_F'] = json.pop('tempF')
+    if 'temp_C' not in json:
+      json['temp_C'] = json.pop('tempC')
+    if 'temp_F' not in json:
+      json['temp_F'] = json.pop('tempF')
     
     super().__init__(json, unit, locale)
   


### PR DESCRIPTION
https://github.com/null8626/python-weather/issues/35

If DailyForecast.hourly was called more than once, a KeyError would occur due to trying to pop 'tempC'/'tempF' from the json dictionary even though it was already removed the first time it was called.

This issue is resolved by only attempting the key rename if the new key does not exist.