### PR TITLE
Ultraviolet Enum Returning Incorrect Values

### DIFF
--- a/python_weather/enums.py
+++ b/python_weather/enums.py
@@ -45,7 +45,7 @@ class Ultraviolet(BasicEnum):
   
   __slots__ = ()
   
-  LOW = auto()
+  LOW = 13
   MODERATE = auto()
   HIGH = auto()
   VERY_HIGH = auto()


### PR DESCRIPTION
wttr.in has UV values ranging from 1 to 12. This is supposed to get mapped to LOW, MODERATE, HIGH, VERY_HIGH, or EXTREME. However, the mapping is incorrect due to declarations using the auto keyword. e.g. If wttr returns a UV value of 5, EXTREME gets returned instead of MODERATE.

By starting the enum values at 13, it is outside the range of valid wttr values, so it will return the correct enum value.
