### PR TITLE
fix: expect text/plain MIME type from wttr.in API reponses

### DIFF
--- a/python_weather/client.py
+++ b/python_weather/client.py
@@ -183,7 +183,7 @@ class Client:
           resp.raise_for_status()
 
           return Forecast(
-            await resp.json(content_type='application/text'), unit, locale
+            await resp.json(content_type='text/plain'), unit, locale
           )
       except ClientResponseError:
         if attempts == self._max_retries:


### PR DESCRIPTION
The MIME type of the responses from wttr.in seems to have changed to `text/plain` for some reason which caused `Client.get()` to fail 100% of the time, returning the following stack trace:

```
Traceback (most recent call last):
  File "/home/pi/dev/python/weather-test/main.py", line 9, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/pi/dev/python/weather-test/main.py", line 5, in main
    weather = await client.get("Winnipeg")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/dev/python/python-weather/python_weather/client.py", line 190, in get
    raise RequestError(status, reason) from None
python_weather.errors.RequestError: 200: OK
```

The fix was as simple as changing the expected value `application/text` to `text/plain` in the call to `resp.json()`.

All tests pass with PyTest:

```
$ pytest
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.11.2, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/pi/dev/python/python-weather
configfile: pyproject.toml
plugins: cov-7.1.0, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1298 items                                                                                                                                                                                                                         

test_client.py ............................................                                                                                                                                                                            [  3%]
test_enums.py ........................................................................................................................................................................................................................ [ 20%]
...................................................................................................................................................................................................................................... [ 37%]
...................................................................................................................................................................................................................................... [ 55%]
...................................................................................................................................................................................................................................... [ 73%]
...................................................................................................................................................................................................................................... [ 90%]
......................................................................................................................                                                                                                                 [100%]

=========================================================================================================== 1298 passed in 15.73s ============================================================================================================
```