### PR TITLE
fix: use observation_time for forecast datetime field

### DIFF
--- a/python_weather/forecast.py
+++ b/python_weather/forecast.py
@@ -257,7 +257,10 @@ class Forecast(BaseForecast):
     self.region = nearest['region'][0]['value']
     self.location = nearest['areaName'][0]['value']
     self.country = nearest['country'][0]['value']
-    self.datetime = datetime.strptime(current['localObsDateTime'], '%Y-%m-%d %I:%M %p')
+    self.datetime = datetime.combine(
+      datetime.today(),
+      datetime.strptime(current['observation_time'], '%I:%M %p').time()
+    )
 
     try:
       req = next(filter(lambda x: x['type'] == 'LatLon', json['request']))


### PR DESCRIPTION
The `localObsDateTime` field seems to have been removed from the wttr.in JSON response as a KeyError is currently being raised every time `Client.get` is called. Fixed using the `current_time` field instead, and assuming the date to be today's date.